### PR TITLE
Add fix for the protobuf/mapstruct issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 /build/classes/java/main/
 /build/extracted-include-protos/
 /build/resources/
+
+# IDE related directories
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Protobuf 3 + Mapstruct Mapping issue
 
-Just run Tester application and you gonna see
+Revert to `9779df9d94a9c9489f4ffa696fe89cbbcdedbadd` commit and run the tester application to reproduce the issue. 
 ```
 SetObjectMapperImpl.java:44: error: ProtocolStringList is abstract; cannot be instantiated
 ProtocolStringList protocolStringList = new ProtocolStringList();
 ```
+
+The issue has been fixed using [mapstruct-spi-protobuf](https://github.com/entur/mapstruct-spi-protobuf), take a look at the build.gradle file to see 
+how it has been fixed.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    mapstruct = '1.3.0.Final'
+    mapstruct = '1.4.2.Final'
 }
 
 buildscript {
@@ -67,8 +67,9 @@ sourceSets {
 dependencies {
     compile("com.google.protobuf:protobuf-java:3.7.1")
     compile("io.grpc:grpc-services:1.20.0")
-    compile("org.mapstruct:mapstruct-jdk8:${mapstruct}")
+    implementation "org.mapstruct:mapstruct:${mapstruct}"
     annotationProcessor("org.mapstruct:mapstruct-processor:${mapstruct}")
+    annotationProcessor "no.entur.mapstruct.spi:protobuf-spi-impl:1.14"
 
     testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/inc/blackhorse/pmmi/SetObjectMapper.java
+++ b/src/main/java/inc/blackhorse/pmmi/SetObjectMapper.java
@@ -11,7 +11,7 @@ public interface SetObjectMapper {
 
     SetObjectMapper INSTANCE = Mappers.getMapper(SetObjectMapper.class);
 
-    @Mapping(target = "set1List", source = "set1")
-    @Mapping(target = "set2List", source = "set2")
+    @Mapping(target = "set1", source = "set1")
+    @Mapping(target = "set2", source = "set2")
     SetsHolder toGrpc(SetsHolderModel model);
 }


### PR DESCRIPTION
The issue is an old one and you might have already fixed it for yourself. I thought it might still be helpful to someone facing the same issue. See if you'd like to merge it. 

Generated code after this code fix looks like: 

```
        if ( model.getSet1() != null ) {
            for ( String set1 : model.getSet1() ) {
                setsHolder.addSet1( set1 );
            }
        }
        if ( model.getSet2() != null ) {
            for ( String set2 : model.getSet2() ) {
                setsHolder.addSet2( set2 );
            }
        }
```

before code fix:
```
        if ( setsHolder.getSet1List() != null ) {
            ProtocolStringList protocolStringList = stringSetToProtocolStringList( model.getSet1() );
            if ( protocolStringList != null ) {
                setsHolder.getSet1List().addAll( protocolStringList );
            }
        }
        if ( setsHolder.getSet2List() != null ) {
            ProtocolStringList protocolStringList1 = stringSetToProtocolStringList( model.getSet2() );
            if ( protocolStringList1 != null ) {
                setsHolder.getSet2List().addAll( protocolStringList1 );
            }
        }
        return setsHolder.build();
    }


    protected ProtocolStringList stringSetToProtocolStringList(Set<String> set) {
        if ( set == null ) {
            return null;
        }

        ProtocolStringList protocolStringList = new ProtocolStringList();
        for ( String string : set ) {
            protocolStringList.add( string );
        }

        return protocolStringList;
    }
```

Thanks